### PR TITLE
At-distance aggro fix

### DIFF
--- a/Assets/Scenes/TitleScreen.unity
+++ b/Assets/Scenes/TitleScreen.unity
@@ -18127,9 +18127,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1886349204}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 50, y: -50}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1228320050

--- a/Assets/Scripts/Enemies/Enemy Frame.cs
+++ b/Assets/Scripts/Enemies/Enemy Frame.cs
@@ -149,6 +149,13 @@ public class EnemyFrame : MonoBehaviour
     public void takeDamage(int damage, Vector3 forwardDir, DamageSource targetSource, DamageType damageType)
     {
         if (enemyReference.isInvincible) return;
+
+        // Damage info for state - Aisling
+        onDamaged = true;
+        source = targetSource;
+
+        Debug.LogWarning("onDamaged is " + onDamaged);
+
         Debug.Log("Taken damage of type " + damageType);
         switch(damageType)
         {
@@ -157,10 +164,6 @@ public class EnemyFrame : MonoBehaviour
                 iceEffect.execute();
                 break;
         }
-
-        // Damage info for state - Aisling
-        onDamaged = true;
-        source = targetSource;
         
         if(enemyReference != null)
         {

--- a/Assets/Scripts/Enemies/EnemyLOS.cs
+++ b/Assets/Scripts/Enemies/EnemyLOS.cs
@@ -29,7 +29,7 @@ public class EnemyLOS : MonoBehaviour
 
     // Scope of visual field (in-editor configurable)
     [SerializeField] private float detectionRange = 7;
-    [SerializeField] private float visionAngle = 90;
+    [SerializeField] private int visionAngle = 90;
 
     // Enable xray vision
     [SerializeField] private bool canSeeThroughWalls = false;
@@ -64,6 +64,51 @@ public class EnemyLOS : MonoBehaviour
         myHeading = transform.forward;
     }
 
+    public void SetDetectionRange(float range)
+    {
+        detectionRange = range;
+    }
+
+    public void SetVisionAngle(int angle)
+    {
+        visionAngle = angle;
+    }
+
+    public void SetLastKnownTargetPosition(Vector3 position)
+    {
+        lastKnownTargetPos = position;
+    }
+
+    public float GetDistanceToTarget()
+    {
+        return distancetotarget;
+    }
+
+    public GameObject GetCurrentTargetObject()
+    {
+        return currentTarget;
+    }
+
+    public Vector3 GetCurrentTargetPosition()
+    {
+        return targetPos;
+    }
+
+    public Vector3 GetLastKnownTargetPosition()
+    {
+        return lastKnownTargetPos;
+    }
+
+    public float GetDistanceToLastKnownPos()
+    {
+        return Vector3.Distance(lastKnownTargetPos, selfPos);
+    }
+
+    public float GetDistanceToPosition(Vector3 position)
+    {
+        return Vector3.Distance(position, selfPos);
+    }
+
     // ChangeTarget takes a gameobject (a new target) and switches the current target to the new target
     // Returns true if successful, returns false if the new target is null (a null target causes errors)
     public bool ChangeTarget(GameObject newTarget)
@@ -77,11 +122,6 @@ public class EnemyLOS : MonoBehaviour
         {
             return false;
         }
-    }
-
-    public void ResetTarget()
-    {
-        currentTarget = null;
     }
 
     // Return the tag of the collider spotted
@@ -155,11 +195,6 @@ public class EnemyLOS : MonoBehaviour
         {
             return false;
         }
-    }
-
-    public float GetDistanceToTarget()
-    {
-        return distancetotarget;
     }
 
     void OnDrawGizmosSelected()

--- a/Assets/Scripts/Enemies/State Machine/Concrete States/EnemySearchState.cs
+++ b/Assets/Scripts/Enemies/State Machine/Concrete States/EnemySearchState.cs
@@ -1,3 +1,7 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
 public class EnemySearchState : EnemyNeutralState
 {
     public override void EnterState(EnemyStateManager stateContext)
@@ -10,22 +14,27 @@ public class EnemySearchState : EnemyNeutralState
         // Enemy should be able to move if searching, unless forcibly stopped
         stateContext.agent.isStopped = stateContext.movementPaused;
 
+        // Get players current position (called only once here in Start()) amd set to the last known target position
+        UpdateLastKnownTargetPosition();
+
+        // Move to the last known target position
         stateContext.MoveTo(stateContext.enemyLOS.lastKnownTargetPos, false);
+        stateContext.CustomDebugLog("Moving to " + stateContext.enemyLOS.lastKnownTargetPos + " from " + stateContext.enemyLOS.selfPos);
     }
 
     public override void RunState()
     {
         stateContext.agent.isStopped = stateContext.movementPaused;
         
-        base.OnDamaged();
         if (stateContext.TargetSpotted() == stateContext.GetCurrentTargetTag())
         {
             stateContext.ChangeState(stateContext.chaseState);
         }
         else
         {
-            if (stateContext.transform.position == stateContext.enemyLOS.lastKnownTargetPos)
+            if (stateContext.EnemyIsAtPosition(stateContext.enemyLOS.lastKnownTargetPos))
             {
+                stateContext.CustomDebugLog("Arrived at last known player position, switching to idle.");
                 stateContext.ChangeState(stateContext.idleState);
             }
         }
@@ -34,5 +43,18 @@ public class EnemySearchState : EnemyNeutralState
     public override void ExitState()
     {
         stateContext.CustomDebugLog("Exited " + stateName + " state");
+    }
+
+    private void UpdateLastKnownTargetPosition() // Updates last known target position in enemyLOS
+    {
+        if (stateContext.enemyLOS.GetCurrentTargetObject() != null)
+        {
+            Vector3 ESS_targetPosition = stateContext.enemyLOS.GetCurrentTargetPosition();
+            stateContext.enemyLOS.SetLastKnownTargetPosition(ESS_targetPosition);
+        }
+        else
+        {
+            stateContext.CustomDebugLogError("EnemySearchState.cs UpdateLastKnownTargetPosition() - Current target was found null.");
+        }
     }
 }

--- a/Assets/Scripts/Enemies/State Machine/EnemyNeutralState.cs
+++ b/Assets/Scripts/Enemies/State Machine/EnemyNeutralState.cs
@@ -1,22 +1,27 @@
 // Super state for more common functionalities of basic states - Aisling
 
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
 public abstract class EnemyNeutralState : EnemyState
 {
     protected virtual void OnDamaged()
     {
-        // if (stateContext.enemyFrame.onDamaged)
-        // {
-        //     stateContext.enemyFrame.onDamaged = false; // Reset onDamaged
-
-        //     stateContext.CustomDebugLog("Enemy damaged by " + stateContext.enemyFrame.source);
-        //     switch (stateContext.enemyFrame.source)
-        //     {
-        //         case EnemyFrame.DamageSource.Player:
-        //             // Target player
-        //             stateContext.enemyLOS.ChangeTarget(stateContext.enemyLOS.player);
-        //             stateContext.ChangeState(stateContext.chaseState);
-        //             break;
-        //     }
-        // }
+        if (stateContext.enemyFrame.onDamaged)
+        {
+            Debug.Log("EnemyNeutralState.cs - Enemy damaged by " + stateContext.enemyFrame.source);
+            switch (stateContext.enemyFrame.source)
+            {
+                case EnemyFrame.DamageSource.Player:
+                    // Target player
+                    GameObject player = GameObject.FindWithTag("Player");
+                    stateContext.enemyLOS.ChangeTarget(player);
+                    stateContext.enemyLOS.SetLastKnownTargetPosition(stateContext.enemyLOS.GetCurrentTargetPosition()); // Ensure LKTP is updated
+                    stateContext.ChangeState(stateContext.searchState); // Search will go to the target regardless of if its in LoS
+                    break;
+            }
+            stateContext.enemyFrame.onDamaged = false; // Reset onDamaged
+        }
     }
 }

--- a/Assets/Scripts/Enemies/State Machine/EnemyStateManager.cs
+++ b/Assets/Scripts/Enemies/State Machine/EnemyStateManager.cs
@@ -13,13 +13,14 @@ public class EnemyStateManager : MonoBehaviour, IStateMachine
 
     public float defaultMovementSpeed = 2f; // Movement speed of enemy
     public float engagementRange = 1f; // How close, from target, the enemy will get to the target (radius). Set with SetEngagementRange(float range)
+    public float inaccuracyPointTolerance = 1; // Effectively the "range" surrounding a target point; if the enemy gets within this distance from the point, then it will flag itself as having reached the position
+    // ^ Used in EnemySearchState to allow the enemy to 
 
     // Debugging
     public float currentSpeed;
 
     // Movement pausing
     public bool movementPaused = false;
-    // public float waitTime = 0;
 
     // ----------------------------------------------
     // Components
@@ -34,7 +35,7 @@ public class EnemyStateManager : MonoBehaviour, IStateMachine
     // ----------------------------------------------
 
     // Current state
-    private EnemyState currentState;
+    [SerializeField] private EnemyState currentState;
 
     // Concrete states
     public EnemyIdleState idleState = new EnemyIdleState();
@@ -71,6 +72,7 @@ public class EnemyStateManager : MonoBehaviour, IStateMachine
 
     public void Update()
     {
+        enemyFrame = GetComponent<EnemyFrame>();
         agent.speed = currentSpeed;
 
         if (currentState != null)
@@ -98,6 +100,14 @@ public class EnemyStateManager : MonoBehaviour, IStateMachine
         if (enableStateDebugLogs == true)
         {
             Debug.Log("SM Debug: " + log);
+        }
+    }
+
+    public void CustomDebugLogError(string log)
+    {
+        if (enableStateDebugLogs == true)
+        {
+            Debug.Log("SM Debug ERROR: " + log);
         }
     }
 
@@ -174,6 +184,20 @@ public class EnemyStateManager : MonoBehaviour, IStateMachine
             movementPaused = true;
             yield return new WaitForSeconds(s);
             movementPaused = false;
+        }
+    }
+
+    public bool EnemyIsAtPosition(Vector3 position)
+    {
+        float distance = enemyLOS.GetDistanceToPosition(position);
+
+        if (distance <= inaccuracyPointTolerance)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixed an issue where enemies were not aggroing the player when damaged from a distance.
Added some more getters/setters/other useful functions, largely related to target and enemy position.
Discovered another issue (prior to any changes made in this pull) that causes enemies to aggro to the target regardless of if the target is in the vision cone.